### PR TITLE
Logica mailer

### DIFF
--- a/correoDeConfirmacion.html
+++ b/correoDeConfirmacion.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <style>
+      h1 {
+        font-size: 45px;
+      }
+      p {
+        font-size: 20px;
+      }
+      .encabezado{
+        border-bottom: solid 2px #9a5534;
+      }
+      .banner {
+        text-align: center;
+      }
+      .contenedorBienvenida {
+        margin: 40px 40px;
+        background-color: #f1e4c3;
+        border-radius: 15px;
+        padding-top: 10px;
+      }
+      .parrafo {
+        text-align: center;
+      }
+      .contenedorBotonHacerPedido {
+        text-align: center;
+        margin-top: 50px;
+      }
+      .botonHacerPedido {
+        padding: 15px 10px;
+        background-color: #9a5534;
+        color: #fbf8ef;
+        border-radius: 10px;
+        font-size: 20px;
+        text-decoration: none;
+      }
+      .footer {
+        text-align: center;
+        border-top: solid 2px #9a5534;
+        margin-top: 80px;
+      }
+      .contenedorLinksFooter{
+        margin-top: 10px;
+      }
+      .footerDerechos{
+        font-size: 15px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="contenedorBienvenida">
+      <div class="encabezado">
+        <div>
+          <div class="banner">
+            <h1>~Ambiente Bohemio te da la bienvenida~</h1>
+            <h2>
+              Gracias por elegirnos, una gran cantidad de beneficios te esperan
+            </h2>
+          </div>
+        </div>
+      </div>
+      <div>
+        <div class="parrafo">
+          <p>
+            Podés empezar agregando productos y adminstrando tu pedido haciendo
+            click en el siguiente botón
+          </p>
+        </div>
+        <div class="contenedorBotonHacerPedido">
+          <a
+            class="botonHacerPedido"
+            href="https://dev-maquetado-ambientebohemio.netlify.app/menu"
+            >Hacer un pedido</a
+          >
+        </div>
+      </div>
+      <div class="footer">
+        <div class="contenedorLinksFooter">
+          <a href="https://dev-maquetado-ambientebohemio.netlify.app/*">Términos y condiciones</a>
+          <a href="https://dev-maquetado-ambientebohemio.netlify.app/nosotros">Más sobre Ambiente Bohemio</a>
+        </div>
+        <p class="footerDerechos">
+          &copy; AmbienteBohemio. Todos los derechos reservados. 2024.
+          Desarrollado por Grupo 2
+        </p>
+      </div>
+    </div>
+  </body>
+</html>

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ import enrutadorProductos from './src/routes/productos.routes.js';
 import enrutadorUsuarios from './src/routes/usuarios.routes.js';
 import './src/database/database.js';
 import enrutadorPedidos from './src/routes/pedidos.routes.js';
+import enrutadorMailer from "./src/routes/mailer.routes.js"
 
 const app = express();
 app.set('port', process.env.PORT || 4000);
@@ -28,3 +29,4 @@ app.use(express.static(path.join(__dirname, '/public')));
 app.use('/api', enrutadorProductos);
 app.use('/api', enrutadorUsuarios);
 app.use('/api', enrutadorPedidos);
+app.use('/api', enrutadorMailer);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,12 @@
         "dotenv": "^16.4.5",
         "express": "^4.19.2",
         "express-validator": "^7.0.1",
+        "fs-extra": "^11.2.0",
+        "handlebars": "^4.7.8",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.3.0",
         "morgan": "^1.10.0",
+        "nodemailer": "^6.9.13",
         "nodemon": "^3.1.0"
       }
     },
@@ -591,6 +594,19 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/fs-extra": {
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
+      "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
@@ -715,6 +731,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
       }
     },
     "node_modules/has-flag": {
@@ -904,6 +945,17 @@
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -1097,6 +1149,14 @@
       },
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/minipass": {
@@ -1331,6 +1391,11 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
+    },
     "node_modules/node-addon-api": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
@@ -1353,6 +1418,14 @@
         "encoding": {
           "optional": true
         }
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "6.9.13",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.9.13.tgz",
+      "integrity": "sha512-7o38Yogx6krdoBf3jCAqnIN4oSQFx+fMa0I7dK1D+me9kBxx12D+/33wSb+fhOCtIxvYJ+4x4IMEhmhCKfAiOA==",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemon": {
@@ -1754,6 +1827,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -1890,10 +1971,30 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/uglify-js": {
+      "version": "3.17.4",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.17.4.tgz",
+      "integrity": "sha512-T9q82TJI9e/C1TAxYvfb16xO120tMVFZrGA3f9/P4424DNu6ypK103y0GPFVa17yotwSyZW5iYXgjYHkGrJW/g==",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
       "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA=="
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -1953,6 +2054,11 @@
       "dependencies": {
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -17,9 +17,12 @@
     "dotenv": "^16.4.5",
     "express": "^4.19.2",
     "express-validator": "^7.0.1",
+    "fs-extra": "^11.2.0",
+    "handlebars": "^4.7.8",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.3.0",
     "morgan": "^1.10.0",
+    "nodemailer": "^6.9.13",
     "nodemon": "^3.1.0"
   }
 }

--- a/src/controllers/mailer.controllers.js
+++ b/src/controllers/mailer.controllers.js
@@ -1,0 +1,32 @@
+import fs from "fs-extra";
+import transporter from "../helpers/mailer.js";
+import Handlebars from "handlebars";
+import { readFileSync } from "fs";
+import { fileURLToPath } from "url";
+import path from "path";
+
+export const enviarCorreo = async (req, res) => {
+  const pathHTML = path.resolve("correoDeConfirmacion.html");
+  console.log(pathHTML);
+  const template = fs.readFileSync(pathHTML, "utf8").toString();
+  console.log(template);
+  const { correo } = req.body;
+  try {
+    const resultado = await transporter.sendMail({
+      from: `AmbienteBohemio ${process.env.EMAIL}`,
+      to: correo,
+      subject: "Registro Ambiente Bohemio",
+      body: "Verificacion",
+      html: template,
+    });
+    console.log(resultado);
+    res.status(200).json({
+      message: "correo enviado exitosamente!",
+    });
+  } catch (error) {
+    console.log(error);
+    res.status(400).json({
+      message: "Hubo un error en la solicitud",
+    });
+  }
+};

--- a/src/helpers/mailer.js
+++ b/src/helpers/mailer.js
@@ -1,0 +1,13 @@
+import nodemailer from "nodemailer";
+
+const transporter = nodemailer.createTransport({
+  host: "smtp.gmail.com",
+  port: 587,
+  secure: false,
+  auth: {
+    user: process.env.EMAIL,
+    pass: process.env.EMAIL_PASSWORD,
+  },
+});
+
+export default transporter

--- a/src/routes/mailer.routes.js
+++ b/src/routes/mailer.routes.js
@@ -1,0 +1,9 @@
+import { Router } from "express";
+import { enviarCorreo } from "../controllers/mailer.controllers.js";
+
+const enrutador = Router();
+
+enrutador.route('/mailer').post(enviarCorreo)
+
+
+export default enrutador;


### PR DESCRIPTION
Se agregó la lógica necesaria en backend para que se envíe un correo preconfigurado al nuevo cliente registrado desde el front.
Considerar que se instalaron nuevas dependencias: nodemailer, fs-extra y handlebars.
La funcion se puede probar con postman en local con la solicitud post a la ruta adecuada y enviando las propiedades 
correo : uncorreo@valido.com